### PR TITLE
fix a minor bug in parsing coords.txt

### DIFF
--- a/sfminit/bundletypes.py
+++ b/sfminit/bundletypes.py
@@ -103,7 +103,7 @@ class Coords(object):
         # regex expressions for float, int, and string
         import re
         re_d = r'([-+]?\d+)'
-        re_f = r'([-+]?(\d+(\.\d*))?)'
+        re_f = r'([-+]?(\d+(\.\d*))+)'
         re_s = r'([^\s,]*)'
 
         indices = []


### PR DESCRIPTION
line no. 106   ==>   re_f = r'([-+]?(\d+(\.\d*))+)'
so that the program will not crash when
line = r'#index = 0, name = images/1022056833_b0bcddb09e_o.jpg, keys = 276, px = 320.0, py = 240.0, focal = -'
for example